### PR TITLE
feat(cmd): implement config inspection

### DIFF
--- a/cmd/mg/cmd/config.go
+++ b/cmd/mg/cmd/config.go
@@ -1,21 +1,44 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/taigrr/mg/parse"
 )
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "",
-	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("config called")
+	Short: "inspect mg configuration",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		configPath, err := parse.MGConfigPath()
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), configPath)
+		return err
+	},
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "print the active mg configuration",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		conf := GetConfig()
+		configJSON, err := json.MarshalIndent(conf, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), string(configJSON))
+		return err
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configShowCmd)
 }

--- a/parse/mgconf.go
+++ b/parse/mgconf.go
@@ -85,24 +85,36 @@ func (m *MGConfig) Merge(m2 MGConfig) (Stats, error) {
 	return stats, nil
 }
 
+// MGConfigPath returns the active mgconfig path from MGCONFIG, XDG_CONFIG_HOME,
+// or the default $HOME/.config/mgconfig location.
+func MGConfigPath() (string, error) {
+	mgConf := os.Getenv("MGCONFIG")
+	if mgConf != "" {
+		return mgConf, nil
+	}
+
+	confDir := os.Getenv("XDG_CONFIG_HOME")
+	if confDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		confDir = filepath.Join(home, ".config")
+	}
+	if _, err := os.Stat(confDir); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(confDir, "mgconfig"), nil
+}
+
 // LoadMGConfig loads the mgconfig file from the XDG_CONFIG_HOME directory
 // or from the default location of $HOME/.config/mgconfig
 // If the file is not found, an error is returned
 func LoadMGConfig() (MGConfig, error) {
-	mgConf := os.Getenv("MGCONFIG")
-	if mgConf == "" {
-		confDir := os.Getenv("XDG_CONFIG_HOME")
-		if confDir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return MGConfig{}, err
-			}
-			confDir = filepath.Join(home, ".config")
-			if _, err := os.Stat(confDir); err != nil {
-				return MGConfig{}, err
-			}
-		}
-		mgConf = filepath.Join(confDir, "mgconfig")
+	mgConf, err := MGConfigPath()
+	if err != nil {
+		return MGConfig{}, err
 	}
 	file, err := os.ReadFile(mgConf)
 	if err != nil {
@@ -141,20 +153,9 @@ func (m *MGConfig) CollapsePaths() {
 }
 
 func (m MGConfig) Save() error {
-	mgConf := os.Getenv("MGCONFIG")
-	if mgConf == "" {
-		confDir := os.Getenv("XDG_CONFIG_HOME")
-		if confDir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return err
-			}
-			confDir = filepath.Join(home, ".config")
-			if _, err := os.Stat(confDir); err != nil {
-				return err
-			}
-		}
-		mgConf = filepath.Join(confDir, "mgconfig")
+	mgConf, err := MGConfigPath()
+	if err != nil {
+		return err
 	}
 	// Collapse paths before saving so config is portable
 	toSave := MGConfig{

--- a/parse/mgconf_test.go
+++ b/parse/mgconf_test.go
@@ -269,6 +269,55 @@ func TestSave_CollapsesPaths(t *testing.T) {
 	}
 }
 
+func TestMGConfigPath(t *testing.T) {
+	t.Run("uses MGCONFIG", func(t *testing.T) {
+		t.Setenv("MGCONFIG", "/tmp/custom-mgconfig")
+
+		path, err := MGConfigPath()
+		if err != nil {
+			t.Fatalf("MGConfigPath() error = %v", err)
+		}
+		if path != "/tmp/custom-mgconfig" {
+			t.Fatalf("MGConfigPath() = %q, want %q", path, "/tmp/custom-mgconfig")
+		}
+	})
+
+	t.Run("uses XDG_CONFIG_HOME", func(t *testing.T) {
+		configDir := t.TempDir()
+		t.Setenv("MGCONFIG", "")
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+
+		path, err := MGConfigPath()
+		if err != nil {
+			t.Fatalf("MGConfigPath() error = %v", err)
+		}
+		wantPath := filepath.Join(configDir, "mgconfig")
+		if path != wantPath {
+			t.Fatalf("MGConfigPath() = %q, want %q", path, wantPath)
+		}
+	})
+
+	t.Run("uses default config dir", func(t *testing.T) {
+		homeDir := t.TempDir()
+		configDir := filepath.Join(homeDir, ".config")
+		if err := os.Mkdir(configDir, 0o755); err != nil {
+			t.Fatalf("failed to create config dir: %v", err)
+		}
+		t.Setenv("HOME", homeDir)
+		t.Setenv("MGCONFIG", "")
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		path, err := MGConfigPath()
+		if err != nil {
+			t.Fatalf("MGConfigPath() error = %v", err)
+		}
+		wantPath := filepath.Join(configDir, "mgconfig")
+		if path != wantPath {
+			t.Fatalf("MGConfigPath() = %q, want %q", path, wantPath)
+		}
+	})
+}
+
 func TestParseMGConfig(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- replace the placeholder config command with active config path output
- add `mg config show` to print the parsed configuration as formatted JSON
- centralize mgconfig path resolution and cover it with tests

## Verification
- `go generate ./...`
- `go test -race ./...`
- `go build ./...`
- `staticcheck ./...`
- `go run ./cmd/mg config`
- `go run ./cmd/mg config show`